### PR TITLE
Git celery task timeout limit

### DIFF
--- a/.github/workflows/sld-api-docker-image.yml
+++ b/.github/workflows/sld-api-docker-image.yml
@@ -26,10 +26,10 @@ jobs:
 
     - name: Build the Docker image with tag
       working-directory: ./sld-api-backend
-      run: docker build . --file Dockerfile --tag ${{ secrets.DOCKER_USERNAME }}/sld-api:2.1.3
+      run: docker build . --file Dockerfile --tag ${{ secrets.DOCKER_USERNAME }}/sld-api:2.1.4
       
     - name: Docker Push with tag
-      run: docker push ${{ secrets.DOCKER_USERNAME }}/sld-api:2.1.3
+      run: docker push ${{ secrets.DOCKER_USERNAME }}/sld-api:2.1.4
 
     - name: Build the Docker image
       working-directory: ./sld-api-backend

--- a/play-with-sld/kubernetes/k8s/sld-api-backend.yml
+++ b/play-with-sld/kubernetes/k8s/sld-api-backend.yml
@@ -17,7 +17,7 @@ spec:
       subdomain: primary
       containers:
         - name: api-backend
-          image: nabilm/sld-api:2.1.2
+          image: nabilm/sld-api:2.1.4
           resources:
             limits:
               memory: 600Mi

--- a/play-with-sld/kubernetes/k8s/sld-worker-default.yml
+++ b/play-with-sld/kubernetes/k8s/sld-worker-default.yml
@@ -17,7 +17,7 @@ spec:
       subdomain: primary
       containers:
         - name: stack-deploy-worker-default
-          image: nabilm/sld-api:latest
+          image: nabilm/sld-api:2.1.4
           imagePullPolicy: Always
           env:
           - name: TF_WARN_OUTPUT_ERRORS

--- a/play-with-sld/kubernetes/k8s/sld-worker-default.yml
+++ b/play-with-sld/kubernetes/k8s/sld-worker-default.yml
@@ -24,9 +24,9 @@ spec:
             value: "1"
           resources:
             limits:
-              memory: 600Mi
+              memory: 1000Mi
               cpu: 1
             requests:
-              memory: 300Mi
+              memory: 500Mi
               cpu: 500m
-          command: ["celery", "--app", "tasks.celery_worker", "worker", "--loglevel=info", "-c", "1", "-E", "-Q", "squad,celery"]
+          command: ["celery", "--app", "tasks.celery_worker", "worker", "--time-limit=7200","--loglevel=info", "-c", "1", "-E", "-Q", "squad,celery"]

--- a/play-with-sld/kubernetes/k8s/sld-worker-squad1.yml
+++ b/play-with-sld/kubernetes/k8s/sld-worker-squad1.yml
@@ -17,7 +17,7 @@ spec:
       subdomain: primary
       containers:
         - name: stack-deploy-worker-squad1
-          image: nabilm/sld-api:latest
+          image: nabilm/sld-api:2.1.4
           imagePullPolicy: Always
           env:
           - name: TF_WARN_OUTPUT_ERRORS

--- a/play-with-sld/kubernetes/k8s/sld-worker-squad2.yml
+++ b/play-with-sld/kubernetes/k8s/sld-worker-squad2.yml
@@ -17,7 +17,7 @@ spec:
       subdomain: primary
       containers:
         - name: stack-deploy-worker-squad2
-          image: nabilm/sld-api:latest
+          image: nabilm/sld-api:2.1.4
           imagePullPolicy: Always
           env:
           - name: TF_WARN_OUTPUT_ERRORS

--- a/sld-api-backend/config/api.py
+++ b/sld-api-backend/config/api.py
@@ -26,7 +26,7 @@ class Settings(BaseSettings):
     PASSWORD_LEN: int = os.getenv('SLD_PASSWORD_LEN', 8)
     ROLLBACK: bool = os.getenv('SLD_ROLLBACK', False)
     DEPLOY_TMOUT: int =os.getenv('SLD_DEPLOY_TMOUT', 7200 ) 
-    GIT_TMOUT: int =os.getenv('SLD_GIT_TMOUT',5 ) 
+    GIT_TMOUT: int =os.getenv('SLD_GIT_TMOUT',300) 
     WORKER_TMOUT: int =os.getenv('SLD_WORKER_TMOUT', 300 ) 
     ENV: str = os.getenv('SLD_ENV', "dev")
     DEBUG: bool = os.getenv('SLD_DEBUG', False)


### PR DESCRIPTION
- Add 300 sec timeout for git celery task, to help internet delays in kind deployment
- Increase memory limit for default worker
- Add a timeout limit on default celery worker